### PR TITLE
Feature(#24): 단일 컨텐츠 업로드

### DIFF
--- a/content_service/build.gradle
+++ b/content_service/build.gradle
@@ -43,12 +43,19 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
 
     // spring cloud
-    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+    //implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     implementation 'io.awspring.cloud:spring-cloud-starter-aws:2.4.4'
 
     // lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+
+    // validation
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // Content Metadata
+    implementation 'com.drewnoakes:metadata-extractor:2.16.0'
+
 
 }
 

--- a/content_service/src/main/java/urdego/ContentServiceApplication.java
+++ b/content_service/src/main/java/urdego/ContentServiceApplication.java
@@ -2,7 +2,9 @@ package urdego;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class ContentServiceApplication {
 

--- a/content_service/src/main/java/urdego/ContentServiceApplication.java
+++ b/content_service/src/main/java/urdego/ContentServiceApplication.java
@@ -1,4 +1,4 @@
-package urdego.content_service;
+package urdego;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/content_service/src/main/java/urdego/api/user/controller/UserContentController.java
+++ b/content_service/src/main/java/urdego/api/user/controller/UserContentController.java
@@ -1,6 +1,6 @@
-package api.user.controller;
+package urdego.api.user.controller;
 
-import api.user.service.UserContentService;
+import urdego.api.user.service.UserContentService;
 
 import lombok.RequiredArgsConstructor;
 

--- a/content_service/src/main/java/urdego/api/user/controller/UserContentController.java
+++ b/content_service/src/main/java/urdego/api/user/controller/UserContentController.java
@@ -1,11 +1,15 @@
 package urdego.api.user.controller;
 
-import urdego.api.user.service.UserContentService;
-
 import lombok.RequiredArgsConstructor;
-
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+import urdego.api.user.controller.request.ContentUploadRequest;
+import urdego.api.user.service.UserContentService;
 
 @RestController
 @RequestMapping("/api/content-service")
@@ -13,4 +17,29 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserContentController {
 
     private final UserContentService userContentService;
+
+
+    // 컨텐츠 단일 등록
+    /*
+      TODO: security 도입후 수정
+     */
+    @PostMapping(value = "/contents", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<Void> uploadContent(@RequestParam("file") MultipartFile file,
+                                              @RequestParam("userId") Long userId,
+                                              @RequestParam("contentName") String contentName,
+                                              @RequestParam("latitude") Double latitude,
+                                              @RequestParam("longitude") Double longitude,
+                                              @RequestParam("hint") String hint) {
+
+        ContentUploadRequest request = ContentUploadRequest.builder()
+                .userId(userId)
+                .contentName(contentName)
+                .latitude(latitude)
+                .longitude(longitude)
+                .hint(hint)
+                .build();
+        userContentService.uploadContent(request, file);
+
+        return ResponseEntity.ok().build();
+    }
 }

--- a/content_service/src/main/java/urdego/api/user/controller/request/ContentUploadRequest.java
+++ b/content_service/src/main/java/urdego/api/user/controller/request/ContentUploadRequest.java
@@ -1,0 +1,25 @@
+package urdego.api.user.controller.request;
+
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ContentUploadRequest {
+
+    private Long userId;
+
+    private String contentName;
+
+    private Double latitude;
+
+    private Double longitude;
+
+    @Size(max = 20, message = "힌트 20자 이내")
+    private String hint;
+}

--- a/content_service/src/main/java/urdego/api/user/service/UserContentService.java
+++ b/content_service/src/main/java/urdego/api/user/service/UserContentService.java
@@ -1,3 +1,3 @@
-package api.user.service;
+package urdego.api.user.service;
 
 public class UserContentService {}

--- a/content_service/src/main/java/urdego/api/user/service/UserContentService.java
+++ b/content_service/src/main/java/urdego/api/user/service/UserContentService.java
@@ -1,3 +1,10 @@
 package urdego.api.user.service;
 
-public class UserContentService {}
+import org.springframework.web.multipart.MultipartFile;
+import urdego.api.user.controller.request.ContentUploadRequest;
+
+public interface UserContentService {
+
+    // 단일 컨텐츠 등록
+    void uploadContent(ContentUploadRequest request, MultipartFile file);
+}

--- a/content_service/src/main/java/urdego/api/user/service/UserContentServiceImpl.java
+++ b/content_service/src/main/java/urdego/api/user/service/UserContentServiceImpl.java
@@ -1,0 +1,54 @@
+package urdego.api.user.service;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import urdego.api.user.controller.request.ContentUploadRequest;
+import urdego.domain.entity.user.UserContent;
+import urdego.domain.entity.user.constant.ContentInfo;
+import urdego.domain.entity.user.repository.UserContentRepository;
+import urdego.external.aws.service.S3Service;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class UserContentServiceImpl implements UserContentService {
+
+    private final S3Service s3Service;
+    private final UserContentRepository userContentRepository;
+
+    @Override
+    public void uploadContent(ContentUploadRequest request, MultipartFile file) {
+
+        String url = uploadFile(request.getUserId(), file);
+
+        // URL을 JSON 문자열로 변환 (단일 값 처리)
+        String urlJson = "\"" + url + "\"";
+
+        ContentInfo contentInfo = contentMetadata(file);
+
+        UserContent userContent = UserContent.builder()
+                .userId(request.getUserId())
+                .contentName(request.getContentName())
+                .url(urlJson)
+                .contentInfo(contentInfo)
+                .latitude(request.getLatitude())
+                .longitude(request.getLongitude())
+                .hint(request.getHint())
+                .build();
+        userContentRepository.save(userContent);
+    }
+
+    // 단일 파일 업로드 처리
+    private String uploadFile(Long userId, MultipartFile file) {
+        return s3Service.uploadSingleContent(userId, file);
+    }
+
+    // 컨텐츠 메타데이터 추출
+    private ContentInfo contentMetadata(MultipartFile file) {
+        return s3Service.extractMetadata(file);
+    }
+}

--- a/content_service/src/main/java/urdego/common/config/ContentServiceConfig.java
+++ b/content_service/src/main/java/urdego/common/config/ContentServiceConfig.java
@@ -1,0 +1,35 @@
+package urdego.common.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.TimeZone;
+
+@Configuration
+public class ContentServiceConfig implements WebMvcConfigurer {
+
+    // JSON 직렬화/역직렬화 시 사용
+    @Bean
+    public ObjectMapper objectMapper() {
+
+        JavaTimeModule javaTimeModule = new JavaTimeModule();
+
+        ObjectMapper mapper = new ObjectMapper();
+
+        // 객체의 속성 이름을 snake-case로 설정
+        mapper.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+
+        // Java 8 날짜/시간 모듈 등록
+        mapper.registerModule(javaTimeModule);
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        mapper.setTimeZone(TimeZone.getTimeZone("Asia/Seoul"));
+
+        return mapper;
+    }
+
+}

--- a/content_service/src/main/java/urdego/common/config/multipart/MultipartConfig.java
+++ b/content_service/src/main/java/urdego/common/config/multipart/MultipartConfig.java
@@ -1,0 +1,19 @@
+package urdego.common.config.multipart;
+
+import jakarta.servlet.MultipartConfigElement;
+import org.springframework.boot.web.servlet.MultipartConfigFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.unit.DataSize;
+
+@Configuration
+public class MultipartConfig {
+
+    @Bean
+    public MultipartConfigElement multipartConfigElement() {
+        MultipartConfigFactory factory = new MultipartConfigFactory();
+        factory.setMaxFileSize(DataSize.ofMegabytes(50)); // 단일 파일 최대 크기
+        factory.setMaxRequestSize(DataSize.ofMegabytes(50)); // 전체 요청 최대 크기
+        return factory.createMultipartConfig();
+    }
+}

--- a/content_service/src/main/java/urdego/common/exception/ContentException.java
+++ b/content_service/src/main/java/urdego/common/exception/ContentException.java
@@ -1,4 +1,4 @@
-package common.exception;
+package urdego.common.exception;
 
 public abstract class ContentException extends RuntimeException {
     public ContentException(String message) {

--- a/content_service/src/main/java/urdego/common/exception/ErrorResponse.java
+++ b/content_service/src/main/java/urdego/common/exception/ErrorResponse.java
@@ -1,0 +1,11 @@
+package urdego.common.exception;
+
+public record ErrorResponse (
+        int status,
+        String title,
+        String message
+) {
+    public static ErrorResponse from(int status, String title, String message) {
+        return new ErrorResponse(status, title, message);
+    }
+}

--- a/content_service/src/main/java/urdego/common/exception/ExceptionMessage.java
+++ b/content_service/src/main/java/urdego/common/exception/ExceptionMessage.java
@@ -1,4 +1,4 @@
-package common.exception;
+package urdego.common.exception;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/content_service/src/main/java/urdego/common/exception/ExceptionMessage.java
+++ b/content_service/src/main/java/urdego/common/exception/ExceptionMessage.java
@@ -8,7 +8,15 @@ import lombok.RequiredArgsConstructor;
 public enum ExceptionMessage {
 
     // UserContent
-    USER_CONTENT_NOT_FOUND("존재하지 않는 유저 콘텐츠입니다.");
+    USER_CONTENT_NOT_FOUND("존재하지 않는 유저 콘텐츠입니다."),
+
+
+    // AWS
+    INVALID_FILE_FORMAT("잘못된 형식의 파일입니다."),
+    FILE_UPLOAD_FAILED("파일 업로드에 실패했습니다."),
+
+    // Image
+    IMAGE_METADATA_FAILED("이미지 메타데이터 추출에 실패했습니다.");
 
     private final String text;
 }

--- a/content_service/src/main/java/urdego/common/exception/GlobalExceptionHandler.java
+++ b/content_service/src/main/java/urdego/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,47 @@
+package urdego.common.exception;
+
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.stream.Collectors;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+    /*
+        데이터 바인딩 중 발생하는 에러 BindException 처리
+     */
+    @ExceptionHandler(BindException.class)
+    public ResponseEntity<ErrorResponse> bindException(BindException e) {
+        String errorMsg = e.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(fieldError -> fieldError.getField() + ": " + fieldError.getDefaultMessage())
+                .collect(Collectors.joining(", "));
+
+        ErrorResponse error = ErrorResponse.from(BAD_REQUEST.value(), BAD_REQUEST.getReasonPhrase(), errorMsg);
+
+        return ResponseEntity.badRequest().body(error);
+    }
+
+    /*
+        @Valid 어노테이션을 사용한 DTO의 유효성 검사에서 예외가 발생한 경우
+     */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValid(MethodArgumentNotValidException e) {
+        String errorMsg = e.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(fieldError -> fieldError.getField() + ": " + fieldError.getDefaultMessage())
+                .collect(Collectors.joining(", "));
+
+        ErrorResponse error = ErrorResponse.from(BAD_REQUEST.value(), BAD_REQUEST.getReasonPhrase(), errorMsg);
+
+        return ResponseEntity.badRequest().body(error);
+    }
+}

--- a/content_service/src/main/java/urdego/common/exception/aws/AwsException.java
+++ b/content_service/src/main/java/urdego/common/exception/aws/AwsException.java
@@ -1,0 +1,10 @@
+package urdego.common.exception.aws;
+
+import urdego.common.exception.ContentException;
+import urdego.common.exception.ExceptionMessage;
+
+public class AwsException extends ContentException {
+    public AwsException(ExceptionMessage message) {
+        super(message.getText());
+    }
+}

--- a/content_service/src/main/java/urdego/common/exception/user/UserContentException.java
+++ b/content_service/src/main/java/urdego/common/exception/user/UserContentException.java
@@ -1,6 +1,6 @@
-package common.exception.user;
+package urdego.common.exception.user;
 
-import common.exception.ContentException;
+import urdego.common.exception.ContentException;
 
 public class UserContentException extends ContentException {
     public UserContentException(String message) {

--- a/content_service/src/main/java/urdego/domain/entity/BaseEntity.java
+++ b/content_service/src/main/java/urdego/domain/entity/BaseEntity.java
@@ -1,4 +1,4 @@
-package domain.entity;
+package urdego.domain.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;

--- a/content_service/src/main/java/urdego/domain/entity/user/UserContent.java
+++ b/content_service/src/main/java/urdego/domain/entity/user/UserContent.java
@@ -1,7 +1,7 @@
-package domain.entity.user;
+package urdego.domain.entity.user;
 
-import domain.entity.BaseEntity;
-import domain.entity.user.constant.ContentInfo;
+import urdego.domain.entity.BaseEntity;
+import urdego.domain.entity.user.constant.ContentInfo;
 
 import jakarta.persistence.*;
 

--- a/content_service/src/main/java/urdego/domain/entity/user/UserContent.java
+++ b/content_service/src/main/java/urdego/domain/entity/user/UserContent.java
@@ -28,16 +28,15 @@ public class UserContent extends BaseEntity {
     private String url;
 
     @Embedded
-    @Column(name = "content_info", length = 255)
     private ContentInfo contentInfo;
 
     @Column(name = "content_name", nullable = false)
     private String contentName;
 
-    @Column(name = "latitude", precision = 10, scale = 7) // DECIMAL
+    @Column(name = "latitude")  // 유저가 핀꽂은 위치
     private Double latitude;
 
-    @Column(name = "longitude", precision = 10, scale = 7) // DECIMAL
+    @Column(name = "longitude")
     private Double longitude;
 
     @Column(name = "hint", length = 255)

--- a/content_service/src/main/java/urdego/domain/entity/user/constant/ContentInfo.java
+++ b/content_service/src/main/java/urdego/domain/entity/user/constant/ContentInfo.java
@@ -1,4 +1,4 @@
-package domain.entity.user.constant;
+package urdego.domain.entity.user.constant;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;

--- a/content_service/src/main/java/urdego/domain/entity/user/constant/ContentInfo.java
+++ b/content_service/src/main/java/urdego/domain/entity/user/constant/ContentInfo.java
@@ -12,23 +12,23 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class ContentInfo {
 
-    @Column(name = "place_name")
-    private String placeName;
+    @Column(name = "content_type")
+    private String contentType; // 파일 콘텐츠 타입 (ex: image/jpg)
 
-    @Column(name = "height")
-    private int height; // 높이
+    @Column(name = "meta_latitude")
+    private Double metaLatitude;   // 컨텐츠 위치정보
 
-    @Column(name = "width")
-    private int width; // 너비
+    @Column(name = "meta_longitude")
+    private Double metaLongitude;
 
     @Column(name = "size")
     private long size; // 사진 크기
 
     @Builder
-    public ContentInfo(String placeName, int height, int width, long size) {
-        this.placeName = placeName;
-        this.height = height;
-        this.width = width;
+    public ContentInfo(String contentType, Double metaLatitude, Double metaLongitude, long size) {
+        this.contentType = contentType;
+        this.metaLatitude = metaLatitude;
+        this.metaLongitude = metaLongitude;
         this.size = size;
     }
 }

--- a/content_service/src/main/java/urdego/domain/entity/user/repository/UserContentRepository.java
+++ b/content_service/src/main/java/urdego/domain/entity/user/repository/UserContentRepository.java
@@ -1,6 +1,6 @@
-package domain.entity.user.repository;
+package urdego.domain.entity.user.repository;
 
-import domain.entity.user.UserContent;
+import urdego.domain.entity.user.UserContent;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/content_service/src/main/java/urdego/external/aws/config/S3Config.java
+++ b/content_service/src/main/java/urdego/external/aws/config/S3Config.java
@@ -1,0 +1,34 @@
+package urdego.external.aws.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3Client() {
+        BasicAWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return AmazonS3ClientBuilder
+                .standard()
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withRegion(region)
+                .build();
+    }
+}
+

--- a/content_service/src/main/java/urdego/external/aws/service/S3Service.java
+++ b/content_service/src/main/java/urdego/external/aws/service/S3Service.java
@@ -1,0 +1,128 @@
+package urdego.external.aws.service;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.drew.imaging.ImageMetadataReader;
+import com.drew.lang.GeoLocation;
+import com.drew.metadata.Metadata;
+import com.drew.metadata.exif.GpsDirectory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import urdego.common.exception.ExceptionMessage;
+import urdego.common.exception.aws.AwsException;
+import urdego.domain.entity.user.constant.ContentInfo;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    private final AmazonS3 s3Client;
+
+
+    // 파일 업로드 (단일 파일)
+    public String uploadSingleContent(Long userId, MultipartFile multipartFile) {
+        String filename = createFilename(userId, multipartFile.getOriginalFilename());
+        ObjectMetadata objectMetadata = new ObjectMetadata();
+        objectMetadata.setContentLength(multipartFile.getSize());
+        objectMetadata.setContentType(multipartFile.getContentType());
+
+        try (InputStream inputStream = multipartFile.getInputStream()) {
+            s3Client.putObject(new PutObjectRequest(bucket, filename, inputStream, objectMetadata)
+                    .withCannedAcl(CannedAccessControlList.PublicRead));
+
+        } catch (IOException e) {
+            throw new AwsException(ExceptionMessage.FILE_UPLOAD_FAILED);
+        }
+
+        // 업로드된 파일의 URL 반환
+        return s3Client.getUrl(bucket, filename).toString();
+    }
+
+
+    // 파일이름 생성
+    public String createFilename(Long userId, String filename) {
+        try {
+            String extension = getFileExtension(filename);
+            return userId + "_" + UUID.randomUUID() + extension; // 유저 ID + UUID + 확장자
+
+        } catch (IllegalArgumentException e) {
+            throw new AwsException(ExceptionMessage.INVALID_FILE_FORMAT);
+        }
+    }
+
+
+    /*
+        Todo: 추후 .webp 확장자로 변경 로직 추가 (크기문제)
+     */
+    // 파일 확장자 추출
+    private String getFileExtension(String filename) {
+        if (filename == null || !filename.contains(".")) {
+            throw new AwsException(ExceptionMessage.INVALID_FILE_FORMAT);
+        }
+        String extension = filename.substring(filename.lastIndexOf(".")).toLowerCase();
+
+        // 유효한 확장자
+        List<String> validExtensions = List.of(".jpg", ".jpeg", ".png", ".mp4");
+
+        // 확장자가 유효하지 않으면 예외 발생
+        if (!validExtensions.contains(extension.toLowerCase())) {
+            throw new AwsException(ExceptionMessage.INVALID_FILE_FORMAT);
+        }
+
+        return extension;
+    }
+
+    // 사진 메타데이터(위치) 추출
+    public double[] extractLocation(MultipartFile file) {
+        try (InputStream inputStream = file.getInputStream()) {
+            // 이미지에서 메타데이터 읽기
+            Metadata metadata = ImageMetadataReader.readMetadata(inputStream);
+
+            // GPS 디렉토리 가져오기
+            GpsDirectory gpsDirectory = metadata.getFirstDirectoryOfType(GpsDirectory.class);
+            if (gpsDirectory != null) {
+                GeoLocation geoLocation = gpsDirectory.getGeoLocation();
+                if (geoLocation != null && !geoLocation.isZero()) {
+                    // 위도(latitude)와 경도(longitude) 반환
+                    return new double[]{geoLocation.getLatitude(), geoLocation.getLongitude()};
+                }
+            }
+        } catch (Exception e) {
+            throw new AwsException(ExceptionMessage.IMAGE_METADATA_FAILED);
+        }
+        return null; // GPS 정보가 없으면 null 반환
+    }
+
+    // 사진 메타데이터(크기) 추출
+    public ContentInfo extractMetadata(MultipartFile multipartFile) {
+        // 위치 정보 추출
+        double[] location = extractLocation(multipartFile);
+        Double latitude = null;
+        Double longitude = null;
+        if (location != null) {
+            latitude = location[0];
+            longitude = location[1];
+        }
+
+        // ContentInfo 객체 생성
+        return ContentInfo.builder()
+                .size(multipartFile.getSize())
+                .contentType(multipartFile.getContentType())
+                .metaLatitude(latitude)
+                .metaLongitude(longitude)
+                .build();
+    }
+
+}

--- a/content_service/src/main/java/urdego/external/aws/service/S3Service.java
+++ b/content_service/src/main/java/urdego/external/aws/service/S3Service.java
@@ -74,7 +74,7 @@ public class S3Service {
         String extension = filename.substring(filename.lastIndexOf(".")).toLowerCase();
 
         // 유효한 확장자
-        List<String> validExtensions = List.of(".jpg", ".jpeg", ".png", ".mp4");
+        List<String> validExtensions = List.of(".jpg", ".jpeg", ".png", ".mp4", ".mov");
 
         // 확장자가 유효하지 않으면 예외 발생
         if (!validExtensions.contains(extension.toLowerCase())) {


### PR DESCRIPTION
## ✅ PR 유형
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other... Please describe:

## #️⃣ 연관된 이슈

#24 

 ## 📝 작업 내용

이미지, 입력데이터 -> S3 적재 , 사용자 입력 저장

S3에 저장시 "userId_UUID_.확장자"  형식으로 넣고 있습니다.
<img width="400" alt="image" src="https://github.com/user-attachments/assets/5ebe247b-b7bb-4b84-b1ab-5ad55b690860">


사진 메타 데이터 추출 가능한지 확인해봤는데
<img width="725" alt="image" src="https://github.com/user-attachments/assets/5676a089-0875-4d48-a37f-5d05db4e5957">
왼쪽 위/경도는 사용자가 핀을 꽂은 위치(프론트에서 받아올)를 저장 중이고
오른쪽(meta) 위/경도는 사진에 저장된 메타데이터 위치를 저장하도록 구현했습니다. (혹시 나중에 쓸일이 있을거같아서 @Embedded로 추가)


군대에서 휴가나올때 버스안에서 찍은 사진인데
<img src="https://github.com/user-attachments/assets/8c70f596-0798-4cf5-8bbb-113b3c28c68a" alt="GitHub PR 이미지" width="150"> <br>

위에 저장된 meta 위경도로 구글 maps API 호출해보니 (https://www.google.com/maps/place/38.28091666666666,128.3573111111111)
<img width="400" alt="스크린샷 2024-11-25 오후 7 35 04" src="https://github.com/user-attachments/assets/5bf85edf-0b57-43f6-80c4-d4934cb349b3">

메타데이터 있는것들은 추출이 가능한것 같네요~~

### 💬 리뷰 요구사항 (선택)

pr이 길어질것 같아 우선 단일 컨텐츠 업로드 먼저 구현했습니다~~

contrller 부분 requestparam 을 requestbody + requestpart 로 받아오고싶었는데
Multipartfile 컨텐츠 업로드와 사용자가 입력하는 데이터를 동시에 받으려니 타입오류가 많네요
삽질좀 많이하고 찾아보니 RequestPart 를 쓸경우 파일 업로드와 클라이언트가 작성하는 데이터를 동시에 가져올수가 없어서  
그냥 동일하게 param으로 해결했습니다


