### PR TITLE
Feature(#55): 유저별 컨텐츠 조회

### DIFF
--- a/content_service/.gitignore
+++ b/content_service/.gitignore
@@ -16,6 +16,7 @@ build/
 bin/
 !**/src/main/**/bin/
 !**/src/test/**/bin/
+/src/main/generated/
 
 ### IntelliJ IDEA ###
 .idea

--- a/content_service/build.gradle
+++ b/content_service/build.gradle
@@ -61,6 +61,39 @@ dependencies {
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
 
+    // QueryDsl
+    implementation "com.querydsl:querydsl-jpa:5.0.0:jakarta"
+    annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+    annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+    annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+}
+
+
+// Querydsl 설정
+def queryDslSrcDir = "${buildDir}/generated/querydsl/"
+
+// QClass 파일 생성 위치를 지정
+tasks.withType(JavaCompile).configureEach {
+    options.getGeneratedSourceOutputDirectory().set(file(queryDslSrcDir))
+}
+
+
+// java source set 에 querydsl QClass 위치 추가
+sourceSets {
+    main.java.srcDirs += [queryDslSrcDir]
+}
+
+// gradle clean 시에 QClass 디렉토리 삭제
+clean {
+    delete file(queryDslSrcDir)
+}
+
+configurations {
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
+    querydsl.extendsFrom compileClasspath
 }
 
 dependencyManagement {

--- a/content_service/src/main/java/io/urdego/content_service/api/user/controller/UserContentController.java
+++ b/content_service/src/main/java/io/urdego/content_service/api/user/controller/UserContentController.java
@@ -1,12 +1,15 @@
 package io.urdego.content_service.api.user.controller;
 
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.urdego.content_service.api.user.controller.request.ContentUploadRequest;
+import io.urdego.content_service.api.user.controller.response.UserContentListAndCursorIdxResponse;
 import io.urdego.content_service.api.user.service.UserContentService;
 import io.urdego.content_service.common.client.UserServiceClient;
 import io.urdego.content_service.common.client.response.UserResponse;
-
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
-
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -24,6 +27,7 @@ public class UserContentController {
     /*
      TODO: security 도입후 수정
     */
+    @ApiResponse(responseCode = "200", description = "컨텐츠 업로드 성공")
     @PostMapping(value = "/contents", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<Void> uploadContent(
             @RequestParam("file") MultipartFile file,
@@ -50,6 +54,7 @@ public class UserContentController {
     }
 
     // 여러 컨텐츠 등록
+    @ApiResponse(responseCode = "200", description = "다중 컨텐츠 업로드 성공")
     @PostMapping(value = "/contents/multiple", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<Void> uploadMultipleContents(
             @RequestParam("files") MultipartFile[] files,
@@ -77,6 +82,7 @@ public class UserContentController {
     }
 
     // 컨텐츠 단일 삭제
+    @ApiResponse(responseCode = "200", description = "컨텐츠 삭제 성공")
     @DeleteMapping(value = "{userId}/contents/{contentId}")
     public ResponseEntity<Void> deleteContent(
             @PathVariable(name = "userId") Long userId,
@@ -88,4 +94,21 @@ public class UserContentController {
         userContentService.deleteContent(contentId);
         return ResponseEntity.ok().build();
     }
+
+    // 컨텐츠 조회
+    @ApiResponse(responseCode = "200", description = "유저 컨텐츠 조회 성공", content = @Content(schema = @Schema(implementation = UserContentListAndCursorIdxResponse.class)))
+    @GetMapping(value = "{userId}/contents")
+    public ResponseEntity<UserContentListAndCursorIdxResponse> getUserContents(@PathVariable(name = "userId") Long userId,
+                                                                               @Min(value = 0) @RequestParam(name = "cursorIdx", required = false) Long cursorIdx,
+                                                                               @Min(value = 1) @RequestParam(name = "limit", defaultValue = "5") Long limit) {
+
+        // Feign 유저 검증
+        UserResponse userResponse = userServiceClient.getUserById(userId);
+
+        UserContentListAndCursorIdxResponse responses = userContentService.getUserContents(userResponse.getUserId(), cursorIdx, limit);
+
+        return ResponseEntity.ok().body(responses);
+    }
+
+
 }

--- a/content_service/src/main/java/io/urdego/content_service/api/user/controller/response/UserContentListAndCursorIdxResponse.java
+++ b/content_service/src/main/java/io/urdego/content_service/api/user/controller/response/UserContentListAndCursorIdxResponse.java
@@ -1,0 +1,26 @@
+package io.urdego.content_service.api.user.controller.response;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Builder
+@Getter
+@AllArgsConstructor
+public class UserContentListAndCursorIdxResponse {
+
+    private Long userId;
+
+    private List<UserContentResponse> userContents; // 컨텐츠 정보
+
+    private Long cursorIdx;
+
+    public void setNextCursorIdx() {
+        cursorIdx = userContents == null || userContents.isEmpty() ?
+                0L : userContents.get(userContents.size() - 1).getUserId();
+
+    }
+}

--- a/content_service/src/main/java/io/urdego/content_service/api/user/controller/response/UserContentResponse.java
+++ b/content_service/src/main/java/io/urdego/content_service/api/user/controller/response/UserContentResponse.java
@@ -1,0 +1,29 @@
+package io.urdego.content_service.api.user.controller.response;
+
+
+import io.urdego.content_service.domain.entity.user.constant.ContentInfo;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class UserContentResponse {
+
+    private Long userId;
+
+    private Long contentId;
+
+    private String url;
+
+    private String contentName;
+
+    private Double latitude;
+
+    private Double longitude;
+
+    private String hint;
+
+    private ContentInfo contentInfo;
+}

--- a/content_service/src/main/java/io/urdego/content_service/api/user/service/UserContentService.java
+++ b/content_service/src/main/java/io/urdego/content_service/api/user/service/UserContentService.java
@@ -1,7 +1,7 @@
 package io.urdego.content_service.api.user.service;
 
 import io.urdego.content_service.api.user.controller.request.ContentUploadRequest;
-
+import io.urdego.content_service.api.user.controller.response.UserContentListAndCursorIdxResponse;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface UserContentService {
@@ -14,4 +14,7 @@ public interface UserContentService {
 
     // 컨텐츠 삭제
     void deleteContent(Long contentId);
+
+    // 컨텐츠 조회
+    UserContentListAndCursorIdxResponse getUserContents(Long userId, Long cursorIdx, Long limit);
 }

--- a/content_service/src/main/java/io/urdego/content_service/domain/config/QueryDslConfig.java
+++ b/content_service/src/main/java/io/urdego/content_service/domain/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package io.urdego.content_service.domain.config;
+
+import com.querydsl.jpa.JPQLTemplates;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+    @PersistenceContext
+    private EntityManager em;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(JPQLTemplates.DEFAULT, em);
+    }
+}

--- a/content_service/src/main/java/io/urdego/content_service/domain/entity/user/repository/UserContentRepository.java
+++ b/content_service/src/main/java/io/urdego/content_service/domain/entity/user/repository/UserContentRepository.java
@@ -4,4 +4,4 @@ import io.urdego.content_service.domain.entity.user.UserContent;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface UserContentRepository extends JpaRepository<UserContent, Long> {}
+public interface UserContentRepository extends JpaRepository<UserContent, Long> , UserContentRepositoryCustom{}

--- a/content_service/src/main/java/io/urdego/content_service/domain/entity/user/repository/UserContentRepositoryCustom.java
+++ b/content_service/src/main/java/io/urdego/content_service/domain/entity/user/repository/UserContentRepositoryCustom.java
@@ -1,0 +1,11 @@
+package io.urdego.content_service.domain.entity.user.repository;
+
+import io.urdego.content_service.api.user.controller.response.UserContentResponse;
+
+import java.util.List;
+
+public interface UserContentRepositoryCustom {
+
+    // userId를 통해 해당 유저의 컨텐츠를 조회한다.
+    List<UserContentResponse> findUserContentsByUserId_CursorPaging(Long userId, Long cursorIdx, Long limit);
+}

--- a/content_service/src/main/java/io/urdego/content_service/domain/entity/user/repository/UserContentRepositoryImpl.java
+++ b/content_service/src/main/java/io/urdego/content_service/domain/entity/user/repository/UserContentRepositoryImpl.java
@@ -1,0 +1,45 @@
+package io.urdego.content_service.domain.entity.user.repository;
+
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import io.urdego.content_service.api.user.controller.response.UserContentResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+import static io.urdego.content_service.domain.entity.user.QUserContent.userContent;
+
+@Component
+@RequiredArgsConstructor
+public class UserContentRepositoryImpl implements UserContentRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<UserContentResponse> findUserContentsByUserId_CursorPaging(Long userId, Long cursorIdx, Long limit) {
+
+        JPAQuery<UserContentResponse> query = queryFactory
+                .select(Projections.constructor(UserContentResponse.class,
+                        userContent.userId,
+                        userContent.id,
+                        userContent.url,
+                        userContent.contentName,
+                        userContent.latitude,
+                        userContent.longitude,
+                        userContent.hint,
+                        userContent.contentInfo))
+                .from(userContent)
+                .where(userContent.userId.eq(userId))
+                .orderBy(userContent.id.asc());
+
+        if (cursorIdx != null) {
+            query = query.where(userContent.id.gt(cursorIdx)); // 먼저 등록한순 (마지막 항목기준 Id 값이 큰값들 조회)
+        }
+
+        return query.limit(limit)
+                .fetch();
+    }
+}


### PR DESCRIPTION
## ✅ PR 유형
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other... Please describe:

## #️⃣ 연관된 이슈

#55 

## 📝 작업 내용

유저별 컨텐츠 조회 한다.

<img width="474" alt="image" src="https://github.com/user-attachments/assets/d6198634-f9b0-467c-b6ed-da09417e87e8">

메인페이지에서 유저별 컨텐츠 조회하는 기능 입니당~

### 💬 리뷰 요구사항 (선택)

QueryDsl 사용해서 cursorIdx, limit 설정하여 5개씩 조회오도록 구현했습니다. 